### PR TITLE
fix UnboundLocalError

### DIFF
--- a/ControlNet-v1-1-nightly/annotator/dwpose/onnxdet.py
+++ b/ControlNet-v1-1-nightly/annotator/dwpose/onnxdet.py
@@ -119,5 +119,6 @@ def inference_detector(session, oriImg):
         iscat = final_cls_inds == 0
         isbbox = [ i and j for (i, j) in zip(isscore, iscat)]
         final_boxes = final_boxes[isbbox]
-
+    else:
+        final_boxes = np.array([])
     return final_boxes


### PR DESCRIPTION
Fix error when `dets` is None:
```
  File "/home/ubuntu/DWPose/ControlNet-v1-1-nightly/annotator/dwpose/onnxdet.py", line 123, in inference_detector
    return final_boxes
UnboundLocalError: local variable 'final_boxes' referenced before assignment
```